### PR TITLE
the 31 chars locallang_csh file name limitation is still at place?

### DIFF
--- a/Documentation/CoreArchitecture/ContextSensitiveHelp(csh)/TheLocallangFilesForCsh/Index.rst
+++ b/Documentation/CoreArchitecture/ContextSensitiveHelp(csh)/TheLocallangFilesForCsh/Index.rst
@@ -29,7 +29,7 @@ Then there are a few other rules to follow:
   Examples where "pages" (5 chars) is the unique name::
 
      locallang_csh_pages.xml    =>   23 chars
-     dk.locallang_csh_pages.xml      =>   26 chars
+     dk.locallang_csh_pages.xml      =>   26 chars 
 
 - Observe the label-key naming by the syntax [fieldname].[type-
   key].[special option] (see previous section)


### PR DESCRIPTION
The extension builder creates files names much longer easily. Just wondering here.
locallang_csh_tx_myextension_domain_model_products.xlf
