### PR TITLE
Add where to find details on configuration-options

### DIFF
--- a/Documentation/CoreArchitecture/Configuration/LocalConfiguration/Index.rst
+++ b/Documentation/CoreArchitecture/Configuration/LocalConfiguration/Index.rst
@@ -152,3 +152,5 @@ MAIL
 
 SYS
   General options which may affect both the frontend and the backend.
+
+Details on the various configuration-options can be found in the install-tool as well as the TYPO3-source at typo3/sysext/core/Configuration/DefaultConfiguration.php. The documentation shown in the install-tool is automatically extracted from those comments of DefaultConfiguration.php.

--- a/Documentation/CoreArchitecture/Configuration/LocalConfiguration/Index.rst
+++ b/Documentation/CoreArchitecture/Configuration/LocalConfiguration/Index.rst
@@ -153,4 +153,4 @@ MAIL
 SYS
   General options which may affect both the frontend and the backend.
 
-Details on the various configuration-options can be found in the install-tool as well as the TYPO3-source at typo3/sysext/core/Configuration/DefaultConfiguration.php. The documentation shown in the install-tool is automatically extracted from those comments of DefaultConfiguration.php.
+Details on the various configuration-options can be found in the install-tool as well as the TYPO3-source at :file:`typo3/sysext/core/Configuration/DefaultConfiguration.php`. The documentation shown in the install-tool is automatically extracted from those comments of DefaultConfiguration.php.


### PR DESCRIPTION
Details on configuration-options in LocalConfiguration.php can be found in the install-tool as well as typo3/sysext/core/Configuration/DefaultConfiguration.php.