### PR TITLE
Change link to user/group page access settings

### DIFF
--- a/Documentation/CoreArchitecture/AccessControl/AccessControlOptions/Index.rst
+++ b/Documentation/CoreArchitecture/AccessControl/AccessControlOptions/Index.rst
@@ -254,7 +254,7 @@ permissions.
 When a user creates new pages in TYPO3 CMS they will by default get the
 creating user as owner. The owner group will be set to the *first
 listed user group* configured for the users record (if any). These defaults
-can be changed through :ref:`Page TSconfig <t3tsconfig:pagetsconfig>`.
+can be changed through :ref:`Page TSconfig <t3tsconfig:pagetcemain-permissions-user-group>`.
 
 
 .. _access-options-user-tsconfig:


### PR DESCRIPTION
Since the section around line 254ff deals with the setting of user/groups access via page TSconfig, the link should point directly to the according TCMain section, not the overview of page TSConfig. Would have saved me some time searching for the right settings ;-)