### PR TITLE
$this->view does not exist before initialisation of the view

### DIFF
--- a/Documentation/CoreArchitecture/BackendModules/TemplateClass/Index.rst
+++ b/Documentation/CoreArchitecture/BackendModules/TemplateClass/Index.rst
@@ -71,7 +71,7 @@ at the "beuser" extension:
             || $this->actionMethodName == 'compareAction') {
             $this->generateMenu();
             $this->registerDocheaderButtons();
-            $this->view->getModuleTemplate()->setFlashMessageQueue($this->controllerContext->getFlashMessageQueue());
+            $view->getModuleTemplate()->setFlashMessageQueue($this->controllerContext->getFlashMessageQueue());
         }
         if ($view instanceof BackendTemplateView) {
             $view->getModuleTemplate()->getPageRenderer()->loadRequireJsModule('TYPO3/CMS/Backend/Modal');


### PR DESCRIPTION
The method uses `$this->view` before the view is initialized. Here, we should use `$view` instead.